### PR TITLE
Fix UUID length overflow

### DIFF
--- a/base57.go
+++ b/base57.go
@@ -75,9 +75,11 @@ func (b *base57) stringToNum(s string) (string, error) {
 
 	x := fmt.Sprintf("%x", n)
 
-	// Pad the most significant bit (MSG) with 0 (zero) if the string is too short.
 	if len(x) < 32 {
+		// Pad the most significant bit (MSG) with 0 (zero) if the string is too short.
 		x = strings.Repeat("0", 32-len(x)) + x
+	} else if len(x) > 32 {
+		return "", fmt.Errorf("UUID length overflow for %q", s)
 	}
 
 	return fmt.Sprintf("%s-%s-%s-%s-%s", x[0:8], x[8:12], x[12:16], x[16:20], x[20:32]), nil

--- a/shortuuid_test.go
+++ b/shortuuid_test.go
@@ -212,6 +212,28 @@ func TestDecoding(t *testing.T) {
 	}
 }
 
+func TestDecodingErrors(t *testing.T) {
+	const (
+		NotPartOfAlphabetError  = "not part of alphabet"
+		UUIDLengthOverflowError = "UUID length overflow"
+	)
+	var tests = []struct {
+		shortuuid string
+		error     string
+	}{
+		{"6B8cwPMGnU6qLbRvo7qEZo", UUIDLengthOverflowError},
+		{"SiKyfue4VDTKnynXckqVNt", UUIDLengthOverflowError},
+		{"122222222222222222222", NotPartOfAlphabetError},
+		{"0a6hrgRGNfQ57QMHZdNYAg", NotPartOfAlphabetError},
+	}
+	for _, test := range tests {
+		_, err := DefaultEncoder.Decode(test.shortuuid)
+		if err == nil {
+			t.Errorf("expected %q error for %q", test.error, test.shortuuid)
+		}
+	}
+}
+
 func TestNewWithAlphabet(t *testing.T) {
 	abc := DefaultAlphabet[:len(DefaultAlphabet)-1] + "="
 	enc := base57{newAlphabet(abc)}

--- a/shortuuid_test.go
+++ b/shortuuid_test.go
@@ -213,7 +213,7 @@ func TestDecoding(t *testing.T) {
 }
 
 func TestDecodingErrors(t *testing.T) {
-	const (
+	var (
 		NotPartOfAlphabetError  = "not part of alphabet"
 		UUIDLengthOverflowError = "UUID length overflow"
 	)
@@ -223,7 +223,7 @@ func TestDecodingErrors(t *testing.T) {
 	}{
 		{"6B8cwPMGnU6qLbRvo7qEZo", UUIDLengthOverflowError},
 		{"SiKyfue4VDTKnynXckqVNt", UUIDLengthOverflowError},
-		{"122222222222222222222", NotPartOfAlphabetError},
+		{"1lIO022222222222222222", NotPartOfAlphabetError},
 		{"0a6hrgRGNfQ57QMHZdNYAg", NotPartOfAlphabetError},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Decode method of DefaultEncoder (base57) doesn't return an error when given a shortuuid string that internally converts to a number longer than 32 hex digits (UUIDs max length), outstanding digits in the returned UUID are simply truncated. Then if such UUID is encoded back to shortuuid its value is different from the initial shortuuid.

shortuuids which overflow UUIDs max length should be recognized by the library as invalid and a corresponding error should be returned.

I implemented this in my pull request, and added a test for decoding errors.