### PR TITLE
Fix `Encode()` when low half of UUID is zero

### DIFF
--- a/base57.go
+++ b/base57.go
@@ -45,7 +45,8 @@ func (b *base57) numToString(number *big.Int, padToLen int) string {
 		digit *big.Int
 	)
 
-	for number.Uint64() > 0 {
+	zero := new(big.Int)
+	for number.Cmp(zero) > 0 {
 		number, digit = new(big.Int).DivMod(number, big.NewInt(b.alphabet.Length()), new(big.Int))
 		out += b.alphabet.chars[digit.Int64()]
 	}

--- a/shortuuid_test.go
+++ b/shortuuid_test.go
@@ -161,6 +161,8 @@ var testVector = []struct {
 	{"ca887b94-e90a-4143-b498-b0f517677e5a", "bLBXoAmYhoJvTHv2FVUz3e"},
 	{"eb9ccaea-9569-4688-a40a-96fe3dd3d6eb", "89hHCpRTfBuhi7hxJDWUvj"},
 	{"00000000-0000-0000-0000-000000000000", "2222222222222"},
+	{"00000000-0000-0000-8000-000000000000", "z7C8BNkRBVT22"},
+	{"00000000-0000-0001-0000-000000000000", "yDNELiVqLxt22"},
 }
 
 func TestGeneration(t *testing.T) {


### PR DESCRIPTION
Previously, `base57.numToString()` would use `number.Uint64()` which
[is undefined](https://pkg.go.dev/math/big#Int.Uint64) if `number`
"cannot be represented in a uint64" which is the case since it starts
off containing a 128 bit integer.

This would cause incorrect encoding of any UUID whose low half bits were
all zero (along with any other cases where those bits were zero after
some number of divisions by `b.alphabet.Length()`).

The first added test shows an edge case that previously passed, the
second an edge case that previously failed.

Switch to using `big.Int.Cmp()` which works with any value.

Fixes https://github.com/lithammer/shortuuid/issues/21