### PR TITLE
fix encoded length calculation

### DIFF
--- a/base57.go
+++ b/base57.go
@@ -22,7 +22,7 @@ func (b base57) Encode(u uuid.UUID) string {
 	num.SetString(strings.Replace(u.String(), "-", "", 4), 16)
 
 	// Calculate encoded length.
-	factor := math.Log(float64(25)) / math.Log(float64(b.alphabet.Length()))
+	factor := 8.0 / math.Log2(float64(b.alphabet.Length()))
 	length := math.Ceil(factor * float64(len(u)))
 
 	return b.numToString(&num, int(length))


### PR DESCRIPTION
The encoded length should always been 22.
either
`32 chars * (Math.log(16)/Math.log(57)) = 21.94452487346092`
or
`16 bytes * 8/Math.log2(57) = 21.944524873460924`
