### PR TITLE
feat: allow custom alphabets with base57 encoder

### DIFF
--- a/shortuuid.go
+++ b/shortuuid.go
@@ -50,3 +50,9 @@ func NewWithAlphabet(abc string) string {
 	enc := base57{newAlphabet(abc)}
 	return enc.Encode(uuid.New())
 }
+
+// WithAlphabet returns a new base57 enocder using the
+// alternative alphabet abc.
+func WithAlphabet(abc string) Encoder {
+	return base57{newAlphabet(abc)}
+}


### PR DESCRIPTION
This change would allow people to use their own alphabets with the base57 encoder, to encode existing UUIDs. 