### PR TITLE
optimizations

### DIFF
--- a/alphabet.go
+++ b/alphabet.go
@@ -16,7 +16,7 @@ type alphabet struct {
 	chars    []rune
 	len      int64
 	encLen   int64
-	maxBytes int64
+	maxBytes uint8
 }
 
 // Remove duplicates and sort it to ensure reproducibility.
@@ -36,7 +36,7 @@ func newAlphabet(s string) alphabet {
 		maxBytes: 1,
 	}
 	for _, c := range a.chars {
-		var b int64
+		var b uint8
 		switch i := uint32(c); {
 		case i <= rune1Max:
 			b = 1

--- a/alphabet.go
+++ b/alphabet.go
@@ -15,7 +15,7 @@ const (
 type alphabet struct {
 	chars    []rune
 	len      int64
-	encLen   int64
+	encLen   uint8
 	maxBytes uint8
 }
 
@@ -32,26 +32,11 @@ func newAlphabet(s string) alphabet {
 	a := alphabet{
 		chars:    abc,
 		len:      int64(len(abc)),
-		encLen:   int64(math.Ceil(128 / math.Log2(float64(len(abc))))),
+		encLen:   uint8(math.Ceil(128 / math.Log2(float64(len(abc))))),
 		maxBytes: 1,
 	}
 	for _, c := range a.chars {
-		var b uint8
-		switch i := uint32(c); {
-		case i <= rune1Max:
-			b = 1
-		case i <= rune2Max:
-			b = 2
-		case i < surrogateMin, surrogateMax < i && i <= rune3Max:
-			b = 3
-		case i > rune3Max && i <= utf8.MaxRune:
-			b = 4
-		default:
-			b = 3
-		}
-		if b > a.maxBytes {
-			a.maxBytes = b
-		}
+		a.maxBytes = max(a.maxBytes, uint8(utf8.RuneLen(c)))
 	}
 
 	return a

--- a/alphabet.go
+++ b/alphabet.go
@@ -33,10 +33,7 @@ func newAlphabet(s string) alphabet {
 		chars:    abc,
 		len:      int64(len(abc)),
 		encLen:   uint8(math.Ceil(128 / math.Log2(float64(len(abc))))),
-		maxBytes: 1,
-	}
-	for _, c := range a.chars {
-		a.maxBytes = max(a.maxBytes, uint8(utf8.RuneLen(c)))
+		maxBytes: uint8(utf8.RuneLen(abc[len(abc)-1])),
 	}
 
 	return a

--- a/encoder.go
+++ b/encoder.go
@@ -66,7 +66,7 @@ func (e encoder) defaultEncode(num uint128) string { // compiler optimizes a lot
 func (e encoder) encode(num uint128) string {
 	var r, ind uint64
 	i := int(e.alphabet.encLen - 1)
-	buf := make([]byte, int64(e.alphabet.encLen*e.alphabet.maxBytes))
+	buf := make([]byte, int64(e.alphabet.encLen)*int64(e.alphabet.maxBytes))
 	lastPlaced := len(buf)
 	l := uint64(e.alphabet.len)
 	d, n := maxPow(l)

--- a/encoder.go
+++ b/encoder.go
@@ -83,7 +83,7 @@ func (e encoder) defaultEncode(num uint128) string { // compiler optimizes a lot
 func (e encoder) encode(num uint128) string {
 	var r, ind uint64
 	i := e.alphabet.encLen - 1
-	buf := make([]byte, e.alphabet.encLen*e.alphabet.maxBytes)
+	buf := make([]byte, e.alphabet.encLen*int64(e.alphabet.maxBytes))
 	curByteInd := len(buf) - 1
 	l := uint64(e.alphabet.len)
 	d, n := maxPow(l)

--- a/encoder.go
+++ b/encoder.go
@@ -99,7 +99,8 @@ func (e encoder) encode(num uint128) string {
 	for ; i >= 0; i-- {
 		curByteInd -= placeRuneEndingAt(buf, e.alphabet.chars[0], curByteInd)
 	}
-	return unsafe.String(&buf[curByteInd+1], len(buf)-curByteInd-1)
+	buf = buf[curByteInd+1:]
+	return unsafe.String(unsafe.SliceData(buf), len(buf)) // same as in strings.Builder
 }
 
 func placeRuneEndingAt(p []byte, r rune, ind int) int {

--- a/encoder.go
+++ b/encoder.go
@@ -48,7 +48,7 @@ func (e encoder) Encode(u uuid.UUID) string {
 func (e encoder) defaultEncode(num uint128) string { // compiler optimizes a lot of divisions by constant
 	var i int
 	var r uint64
-	buf := make([]byte, defaultEncLen)
+	var buf [defaultEncLen]byte
 	for i = defaultEncLen - 1; num.Hi > 0 || num.Lo > 0; {
 		num, r = num.quoRem64(defaultDivisor)
 		for j := 0; j < defaultNDigits && i >= 0; j++ {
@@ -60,7 +60,7 @@ func (e encoder) defaultEncode(num uint128) string { // compiler optimizes a lot
 	for ; i >= 0; i-- {
 		buf[i] = byte(e.alphabet.chars[0])
 	}
-	return string(buf)
+	return string(buf[:])
 }
 
 func (e encoder) encode(num uint128) string {

--- a/shortuuid.go
+++ b/shortuuid.go
@@ -36,11 +36,11 @@ func NewWithNamespace(name string) string {
 	case name == "":
 		u = uuid.New()
 	case hasPrefixCaseInsensitive(name, "https://"):
-		u = hashedUuid(uuid.NameSpaceURL, name)
+		u = hashedUUID(uuid.NameSpaceURL, name)
 	case hasPrefixCaseInsensitive(name, "http://"):
-		u = hashedUuid(uuid.NameSpaceURL, name)
+		u = hashedUUID(uuid.NameSpaceURL, name)
 	default:
-		u = hashedUuid(uuid.NameSpaceDNS, name)
+		u = hashedUUID(uuid.NameSpaceDNS, name)
 	}
 
 	return DefaultEncoder.Encode(u)
@@ -57,7 +57,7 @@ func hasPrefixCaseInsensitive(s, prefix string) bool {
 	return len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix)
 }
 
-func hashedUuid(space uuid.UUID, data string) (u uuid.UUID) {
+func hashedUUID(space uuid.UUID, data string) (u uuid.UUID) {
 	h := sha1.New()
 	h.Write(space[:])                                         //nolint:errcheck
 	h.Write(unsafe.Slice(unsafe.StringData(data), len(data))) //nolint:errcheck

--- a/shortuuid.go
+++ b/shortuuid.go
@@ -1,7 +1,9 @@
 package shortuuid
 
 import (
+	"crypto/sha1"
 	"strings"
+	"unsafe"
 
 	"github.com/google/uuid"
 )
@@ -34,11 +36,11 @@ func NewWithNamespace(name string) string {
 	case name == "":
 		u = uuid.New()
 	case hasPrefixCaseInsensitive(name, "https://"):
-		u = uuid.NewSHA1(uuid.NameSpaceURL, []byte(name))
+		u = hashedUuid(uuid.NameSpaceURL, name)
 	case hasPrefixCaseInsensitive(name, "http://"):
-		u = uuid.NewSHA1(uuid.NameSpaceURL, []byte(name))
+		u = hashedUuid(uuid.NameSpaceURL, name)
 	default:
-		u = uuid.NewSHA1(uuid.NameSpaceDNS, []byte(name))
+		u = hashedUuid(uuid.NameSpaceDNS, name)
 	}
 
 	return DefaultEncoder.Encode(u)
@@ -53,4 +55,16 @@ func NewWithAlphabet(abc string) string {
 
 func hasPrefixCaseInsensitive(s, prefix string) bool {
 	return len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix)
+}
+
+func hashedUuid(space uuid.UUID, data string) (u uuid.UUID) {
+	h := sha1.New()
+	h.Write(space[:])                                         //nolint:errcheck
+	h.Write(unsafe.Slice(unsafe.StringData(data), len(data))) //nolint:errcheck
+	buf := make([]byte, 0, sha1.Size)
+	s := h.Sum(buf)
+	copy(u[:], s)
+	u[6] = (u[6] & 0x0f) | uint8((5&0xf)<<4)
+	u[8] = (u[8] & 0x3f) | 0x80 // RFC 4122 variant
+	return u
 }

--- a/shortuuid.go
+++ b/shortuuid.go
@@ -61,8 +61,7 @@ func hashedUUID(space uuid.UUID, data string) (u uuid.UUID) {
 	h := sha1.New()
 	h.Write(space[:])                                         //nolint:errcheck
 	h.Write(unsafe.Slice(unsafe.StringData(data), len(data))) //nolint:errcheck
-	buf := make([]byte, 0, sha1.Size)
-	s := h.Sum(buf)
+	s := h.Sum(make([]byte, 0, sha1.Size))
 	copy(u[:], s)
 	u[6] = (u[6] & 0x0f) | uint8((5&0xf)<<4)
 	u[8] = (u[8] & 0x3f) | 0x80 // RFC 4122 variant

--- a/shortuuid_test.go
+++ b/shortuuid_test.go
@@ -128,19 +128,28 @@ var testVector = []struct {
 	{"f9ee01c3-2015-4716-930e-4d5449810833", "nUfojcH2M5j9j3Tk5A8mf7"},
 }
 
-func TestGeneration(t *testing.T) {
-	tests := []string{
-		"",
-		"http://www.example.com/",
-		"HTTP://www.example.com/",
-		"example.com/",
+func TestNewWithNamespace(t *testing.T) {
+	var tests = []struct {
+		name string
+		uuid string
+	}{
+		{"http://www.example.com/", "nzUQAfy7CW4Dd4kzLguPSV"},
+		{"HTTP://www.example.com/", "N9ZezvXJcoXvKzwiNmGYmH"},
+		{"Https://www.example.com/", "jSz34Z6QzADzy93ywucXMv"},
+		{"example.com/", "kueUMiGUbGccYhpZK8Czat"},
+		{"うえおなにぬねのウエオナニヌネノうえおなにぬねのウエオナニヌネノ", "Mp2Q7GQSRYnoDZyCtGttDg"},
+		{"う", "dTbaUbVKrhNkkZKEwZxLqa"},
+	}
+	for _, test := range tests {
+		u := NewWithNamespace(test.name)
+
+		if u != test.uuid {
+			t.Errorf("expected %q, got %q", test.uuid, u)
+		}
 	}
 
-	for _, test := range tests {
-		u := NewWithNamespace(test)
-		if len(u) < 20 || len(u) > 24 {
-			t.Errorf("expected %q to be in range [20, 24], got %d", u, len(u))
-		}
+	if NewWithNamespace("") == NewWithNamespace("") {
+		t.Errorf("NewWithNamespace should generate random uuid with empty namespace")
 	}
 }
 

--- a/shortuuid_test.go
+++ b/shortuuid_test.go
@@ -6,10 +6,6 @@ import (
 	"github.com/google/uuid"
 )
 
-func init() {
-	uuid.EnableRandPool()
-}
-
 var testVector = []struct {
 	uuid      string
 	shortuuid string
@@ -254,10 +250,6 @@ func TestAlphabet_MB(t *testing.T) {
 	if u1 != u3 {
 		t.Errorf("expected %q, got %q", u1, u3)
 	}
-}
-
-func init() {
-	uuid.EnableRandPool()
 }
 
 func BenchmarkUUID(b *testing.B) {

--- a/shortuuid_test.go
+++ b/shortuuid_test.go
@@ -148,7 +148,9 @@ func TestNewWithNamespace(t *testing.T) {
 		}
 	}
 
-	if NewWithNamespace("") == NewWithNamespace("") {
+	u1 := NewWithNamespace("")
+	u2 := NewWithNamespace("")
+	if u1 == u2 {
 		t.Errorf("NewWithNamespace should generate random uuid with empty namespace")
 	}
 }

--- a/shortuuid_test.go
+++ b/shortuuid_test.go
@@ -223,6 +223,26 @@ func TestNewWithAlphabet_MultipleBytes(t *testing.T) {
 	}
 }
 
+func TestNewWithAlphabet_Short(t *testing.T) {
+	abc := "うえ"
+	enc := encoder{newAlphabet(abc)}
+	u1 := uuid.MustParse("bcee4c4f-cee8-4413-8f10-0f68d75c797b")
+	exp := "えうええええううえええうえええううえううええうううえううええええええううえええうえええうえううううえうううえうううううえううえええうううええええうううえううううううううええええうええうえうううええうえうえええうえうえええうううええええううえうええええうええ"
+	u2 := enc.Encode(u1)
+	if u2 != exp {
+		t.Errorf("expected uuid to be %q, got %q", exp, u2)
+		return
+	}
+	u3, err := enc.Decode(u2)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if u1 != u3 {
+		t.Errorf("expected %q, got %q", u1, u3)
+	}
+}
+
 func TestAlphabetCustomLen(t *testing.T) {
 	abc := "21345687654123456"
 	enc := encoder{newAlphabet(abc)}

--- a/shortuuid_test.go
+++ b/shortuuid_test.go
@@ -6,6 +6,10 @@ import (
 	"github.com/google/uuid"
 )
 
+func init() {
+	uuid.EnableRandPool()
+}
+
 var testVector = []struct {
 	uuid      string
 	shortuuid string
@@ -250,6 +254,10 @@ func TestAlphabet_MB(t *testing.T) {
 	if u1 != u3 {
 		t.Errorf("expected %q, got %q", u1, u3)
 	}
+}
+
+func init() {
+	uuid.EnableRandPool()
 }
 
 func BenchmarkUUID(b *testing.B) {


### PR DESCRIPTION
Key changes:
 - simplified encoder complexity (now only 2 cases instead of 4, one for default alphabet, other for generic)
 - changed custom alphabets encode to efficiently place runes into a byte slice backwards and avoid unnecessary allocations
 - added `hashedUUID` function to reduce allocation in `NewWithNamespace`, as google's `uuid.NewSHA1` makes 4 unnecessary allocations

Benchamarks:
```
goos: linux
goarch: amd64
pkg: github.com/lithammer/shortuuid/v4
cpu: 12th Gen Intel(R) Core(TM) i5-12400F
                         │   v4.2.0    │                 new                 │
                         │   sec/op    │   sec/op     vs base                │
UUID-12                    123.3n ± 0%   119.6n ± 0%   -3.04% (p=0.000 n=10)
Encoding-12                44.42n ± 1%   42.32n ± 0%   -4.74% (p=0.001 n=10)
EncodingB57_MB-12          123.2n ± 4%   116.5n ± 2%   -5.36% (p=0.001 n=10)
EncodingB16-12             134.5n ± 0%   151.9n ± 0%  +12.98% (p=0.000 n=10)
EncodingB16_MB-12          327.0n ± 1%   191.2n ± 2%  -41.53% (p=0.000 n=10)
Decoding-12                173.9n ± 1%   167.4n ± 1%   -3.79% (p=0.000 n=10)
DecodingB16-12             206.0n ± 1%   200.0n ± 1%   -2.91% (p=0.000 n=10)
DecodingB16_MB-12          254.6n ± 1%   249.9n ± 2%   -1.87% (p=0.015 n=10)
NewWithAlphabet-12         387.2n ± 1%   381.0n ± 2%   -1.61% (p=0.008 n=10)
NewWithAlphabetB16-12      270.4n ± 1%   293.6n ± 1%   +8.56% (p=0.000 n=10)
NewWithAlphabetB16_MB-12   553.5n ± 0%   403.5n ± 1%  -27.10% (p=0.000 n=10)
NewWithNamespace-12        249.3n ± 1%   166.3n ± 1%  -33.29% (p=0.000 n=10)
NewWithNamespaceHttp-12    255.1n ± 3%   169.8n ± 1%  -33.43% (p=0.000 n=10)
NewWithNamespaceHttps-12   256.4n ± 2%   167.4n ± 1%  -34.73% (p=0.000 n=10)
geomean                    206.5n        177.4n       -14.08%

                         │    v4.2.0     │                 new                  │
                         │     B/op      │    B/op     vs base                  │
UUID-12                     24.00 ± 0%     24.00 ± 0%        ~ (p=1.000 n=10) ¹
Encoding-12                 24.00 ± 0%     24.00 ± 0%        ~ (p=1.000 n=10) ¹
EncodingB57_MB-12           72.00 ± 0%     80.00 ± 0%  +11.11% (p=0.000 n=10)
EncodingB16-12              64.00 ± 0%     32.00 ± 0%  -50.00% (p=0.000 n=10)
EncodingB16_MB-12          480.00 ± 0%     96.00 ± 0%  -80.00% (p=0.000 n=10)
Decoding-12                 0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodingB16-12              0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodingB16_MB-12           0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
NewWithAlphabet-12          264.0 ± 0%     264.0 ± 0%        ~ (p=1.000 n=10) ¹
NewWithAlphabetB16-12      128.00 ± 0%     96.00 ± 0%  -25.00% (p=0.000 n=10)
NewWithAlphabetB16_MB-12    544.0 ± 0%     160.0 ± 0%  -70.59% (p=0.000 n=10)
NewWithNamespace-12        200.00 ± 0%     24.00 ± 0%  -88.00% (p=0.000 n=10)
NewWithNamespaceHttp-12    208.00 ± 0%     24.00 ± 0%  -88.46% (p=0.000 n=10)
NewWithNamespaceHttps-12   224.00 ± 0%     24.00 ± 0%  -89.29% (p=0.000 n=10)
geomean                                ²               -51.82%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                         │    v4.2.0    │                 new                  │
                         │  allocs/op   │ allocs/op   vs base                  │
UUID-12                    1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
Encoding-12                1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
EncodingB57_MB-12          2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.000 n=10)
EncodingB16-12             2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.000 n=10)
EncodingB16_MB-12          4.000 ± 0%     1.000 ± 0%  -75.00% (p=0.000 n=10)
Decoding-12                0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodingB16-12             0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
DecodingB16_MB-12          0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
NewWithAlphabet-12         2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
NewWithAlphabetB16-12      3.000 ± 0%     2.000 ± 0%  -33.33% (p=0.000 n=10)
NewWithAlphabetB16_MB-12   5.000 ± 0%     2.000 ± 0%  -60.00% (p=0.000 n=10)
NewWithNamespace-12        5.000 ± 0%     1.000 ± 0%  -80.00% (p=0.000 n=10)
NewWithNamespaceHttp-12    5.000 ± 0%     1.000 ± 0%  -80.00% (p=0.000 n=10)
NewWithNamespaceHttps-12   5.000 ± 0%     1.000 ± 0%  -80.00% (p=0.000 n=10)
geomean                               ²               -47.13%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```