### PR TITLE
Add NewEncoder for reusable custom alphabet encoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,32 @@ shortuuid.NewWithNamespace("http://example.com")
 
 It's possible to use a custom alphabet as well (at least 2
 characters long).  
-It will automatically sort and remove duplicates from your alphabet to ensure consistency
+It will automatically sort and remove duplicates from your alphabet to ensure consistency.
 
 ```go
 alphabet := "23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxy="
 shortuuid.NewWithAlphabet(alphabet) // iZsai==fWebXd5rLRWFB=u
 ```
 
-Bring your own encoder! For example, base58 is popular among bitcoin.
+For better performance when generating multiple UUIDs with the same custom
+alphabet, use `NewEncoder` to create a reusable encoder:
+
+```go
+import "github.com/google/uuid"
+
+alphabet := "23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxy="
+enc := shortuuid.NewEncoder(alphabet)
+
+for i := 0; i < 10; i++ {
+    fmt.Println(enc.Encode(uuid.New()))
+}
+
+// Decode also works
+u, err := enc.Decode("iZsai==fWebXd5rLRWFB=u")
+```
+
+Bring your own encoder! For example, base58 is popular among cryptocurrencies
+like Bitcoin.
 
 ```go
 package main
@@ -72,7 +90,17 @@ func (enc base58Encoder) Decode(s string) (uuid.UUID, error) {
 
 func main() {
 	enc := base58Encoder{}
-	fmt.Println(shortuuid.NewWithEncoder(enc)) // 6R7VqaQHbzC1xwA5UueGe6
+
+	// Generate a new short UUID
+	id := shortuuid.NewWithEncoder(enc)
+	fmt.Println(id) // 6R7VqaQHbzC1xwA5UueGe6
+
+	// Decode it back to a uuid.UUID
+	original, err := enc.Decode(id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(original) // 8ecb52f2-940f-4c2b-88e6-5e7a53bbf541
 }
 ```
 

--- a/shortuuid.go
+++ b/shortuuid.go
@@ -59,9 +59,23 @@ func NewWithNamespace(name string) string {
 // Panics if abc (after removing duplicates) has fewer than 2 characters.
 // The alphabet will be automatically sorted and deduplicated to ensure
 // consistency.
+//
+// For better performance when generating multiple UUIDs with the same alphabet,
+// use NewEncoder to create a reusable encoder instead.
 func NewWithAlphabet(abc string) string {
 	enc := encoder{newAlphabet(abc)}
 	return enc.Encode(uuid.New())
+}
+
+// NewEncoder creates a reusable Encoder from the given alphabet string.
+// This is more efficient than NewWithAlphabet when encoding multiple UUIDs
+// with the same custom alphabet, as the alphabet is only parsed once.
+//
+// Panics if abc (after removing duplicates) has fewer than 2 characters.
+// The alphabet will be automatically sorted and deduplicated to ensure
+// consistency.
+func NewEncoder(abc string) Encoder {
+	return encoder{newAlphabet(abc)}
 }
 
 func hasPrefixCaseInsensitive(s, prefix string) bool {

--- a/shortuuid_test.go
+++ b/shortuuid_test.go
@@ -214,6 +214,23 @@ func TestNewWithAlphabet(t *testing.T) {
 	}
 }
 
+func TestNewEncoder(t *testing.T) {
+	abc := DefaultAlphabet[:len(DefaultAlphabet)-1] + "="
+	enc := NewEncoder(abc)
+	u1 := uuid.MustParse("e9ae9ba7-4fb1-4a6d-bbca-5315ed438371")
+	encoded := enc.Encode(u1)
+	if encoded != "iZsai==fWebXd5rLRWFB=u" {
+		t.Errorf("expected uuid to be %q, got %q", "iZsai==fWebXd5rLRWFB=u", encoded)
+	}
+	decoded, err := enc.Decode(encoded)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if decoded != u1 {
+		t.Errorf("expected %q, got %q", u1, decoded)
+	}
+}
+
 func TestNewWithAlphabet_MultipleBytes(t *testing.T) {
 	abc := DefaultAlphabet[:len(DefaultAlphabet)-2] + "おネ"
 	enc := encoder{newAlphabet(abc)}
@@ -356,6 +373,13 @@ func BenchmarkNewWithAlphabetB16(b *testing.B) {
 func BenchmarkNewWithAlphabetB16_MB(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = NewWithAlphabet("うえおなにぬねのウエオナニヌネノ")
+	}
+}
+
+func BenchmarkNewEncoder(b *testing.B) {
+	enc := NewEncoder("23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxy!")
+	for i := 0; i < b.N; i++ {
+		_ = enc.Encode(uuid.New())
 	}
 }
 


### PR DESCRIPTION
This is more efficient than NewWithAlphabet when encoding multiple UUIDs with the same alphabet, as the alphabet is only parsed once.