### PR TITLE
Add new versioned api (e.g. New → NewV4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,37 @@ import (
 )
 
 func main() {
-	u := shortuuid.New()
+	u := shortuuid.NewV4()
 	fmt.Println(u) // KwSysDpxcBU9FNhGkn2dCf
 }
 ```
 
-To use UUID v5 (instead of the default v4), use `NewWithNamespace(name string)`
-instead of `New()`.
+To use UUID v5 (instead of the default v4), use `NewV5(namespace, name)`:
+
+```go
+shortuuid.NewV5(shortuuid.NameSpaceDNS, "example.com/")
+shortuuid.NewV5(shortuuid.NameSpaceURL, "http://example.com")
+shortuuid.NewV5(shortuuid.NameSpaceOID, "1.2.840.113549")
+shortuuid.NewV5(shortuuid.NameSpaceX500, "CN=example,O=org")
+```
+
+<details>
+<summary>Migrating from NewWithNamespace (deprecated)</summary>
+
+`NewWithNamespace(name)` is deprecated but still available. It uses URL/DNS
+heuristics based on the name prefix, supports `urn:oid:` and `x500:` prefixes,
+and falls back to v4 when the name is empty.
 
 ```go
 shortuuid.NewWithNamespace("http://example.com")
+shortuuid.NewWithNamespace("urn:oid:1.2.840.113549")
+shortuuid.NewWithNamespace("x500:CN=example,O=org")
 ```
+
+See the [NewV5 (FromName) example](https://pkg.go.dev/github.com/lithammer/shortuuid/v4#example-NewV5-FromName)
+for a migration guide.
+
+</details>
 
 It's possible to use a custom alphabet as well (at least 2
 characters long).  
@@ -44,7 +64,13 @@ It will automatically sort and remove duplicates from your alphabet to ensure co
 
 ```go
 alphabet := "23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxy="
-shortuuid.NewWithAlphabet(alphabet) // iZsai==fWebXd5rLRWFB=u
+shortuuid.NewV4WithAlphabet(alphabet) // iZsai==fWebXd5rLRWFB=u
+```
+
+For UUID v5 with a custom alphabet, provide an explicit namespace:
+
+```go
+shortuuid.NewV5WithAlphabet(shortuuid.NameSpaceDNS, "example.com/", alphabet)
 ```
 
 Bring your own encoder! For example, base58 is popular among bitcoin.
@@ -72,7 +98,7 @@ func (enc base58Encoder) Decode(s string) (uuid.UUID, error) {
 
 func main() {
 	enc := base58Encoder{}
-	fmt.Println(shortuuid.NewWithEncoder(enc)) // 6R7VqaQHbzC1xwA5UueGe6
+	fmt.Println(shortuuid.NewV4WithEncoder(enc)) // 6R7VqaQHbzC1xwA5UueGe6
 }
 ```
 

--- a/shortuuid.go
+++ b/shortuuid.go
@@ -15,9 +15,23 @@ import (
 	"github.com/google/uuid"
 )
 
-// DefaultEncoder is the default encoder used when generating new UUIDs, and is
-// based on Base57.
-var DefaultEncoder = b57Encoder{}
+var (
+	// DefaultEncoder is the default encoder used when generating new UUIDs, and is
+	// based on Base57.
+	DefaultEncoder = b57Encoder{}
+
+	// NameSpaceDNS is the UUID DNS namespace.
+	NameSpaceDNS = uuid.NameSpaceDNS
+
+	// NameSpaceURL is the UUID URL namespace.
+	NameSpaceURL = uuid.NameSpaceURL
+
+	// NameSpaceOID is the UUID OID namespace.
+	NameSpaceOID = uuid.NameSpaceOID
+
+	// NameSpaceX500 is the UUID X500 namespace.
+	NameSpaceX500 = uuid.NameSpaceX500
+)
 
 // Encoder is an interface for encoding/decoding UUIDs to strings.
 type Encoder interface {
@@ -25,32 +39,67 @@ type Encoder interface {
 	Decode(string) (uuid.UUID, error)
 }
 
-// New returns a new UUIDv4, encoded with base57.
-func New() string {
+// NewV4 returns a new UUIDv4, encoded with base57.
+func NewV4() string {
 	return DefaultEncoder.Encode(uuid.New())
 }
 
-// NewWithEncoder returns a new UUIDv4, encoded with enc.
-func NewWithEncoder(enc Encoder) string {
+// NewV4WithEncoder returns a new UUIDv4, encoded with enc.
+func NewV4WithEncoder(enc Encoder) string {
 	return enc.Encode(uuid.New())
 }
 
+// NewV4WithAlphabet returns a new UUIDv4, encoded using the alternative
+// alphabet abc.
+//
+// Panics if abc (after removing duplicates) has fewer than 2 characters.
+// The alphabet will be automatically sorted and deduplicated to ensure
+// consistency.
+func NewV4WithAlphabet(abc string) string {
+	enc := encoder{newAlphabet(abc)}
+	return enc.Encode(uuid.New())
+}
+
+// NewV5 returns a new UUIDv5, encoded with base57.
+// The provided namespace is used directly, with no heuristic.
+func NewV5(namespace uuid.UUID, name string) string {
+	return DefaultEncoder.Encode(hashedUUID(namespace, name))
+}
+
+// NewV5WithAlphabet returns a new UUIDv5, encoded using the alternative
+// alphabet abc. The provided namespace is used directly, with no heuristic.
+//
+// Panics if abc (after removing duplicates) has fewer than 2 characters.
+// The alphabet will be automatically sorted and deduplicated to ensure
+// consistency.
+func NewV5WithAlphabet(namespace uuid.UUID, name, abc string) string {
+	enc := encoder{newAlphabet(abc)}
+	return enc.Encode(hashedUUID(namespace, name))
+}
+
+// New returns a new UUIDv4, encoded with base57.
+//
+// Deprecated: Use NewV4.
+func New() string {
+	return NewV4()
+}
+
+// NewWithEncoder returns a new UUIDv4, encoded with enc.
+//
+// Deprecated: Use NewV4WithEncoder.
+func NewWithEncoder(enc Encoder) string {
+	return NewV4WithEncoder(enc)
+}
+
 // NewWithNamespace returns a new UUIDv5 (or v4 if name is empty), encoded with base57.
+//
+// Deprecated: Use NewV5(namespace, name) for explicit namespaces or NewV4 for
+// random v4. This function keeps URL/DNS heuristics and the OID/X500 prefixes.
 func NewWithNamespace(name string) string {
-	var u uuid.UUID
-
-	switch {
-	case name == "":
-		u = uuid.New()
-	case hasPrefixCaseInsensitive(name, "https://"):
-		u = hashedUUID(uuid.NameSpaceURL, name)
-	case hasPrefixCaseInsensitive(name, "http://"):
-		u = hashedUUID(uuid.NameSpaceURL, name)
-	default:
-		u = hashedUUID(uuid.NameSpaceDNS, name)
+	if name == "" {
+		return NewV4()
 	}
-
-	return DefaultEncoder.Encode(u)
+	return DefaultEncoder.Encode(uuidV5FromName(name))
 }
 
 // NewWithAlphabet returns a new UUIDv4, encoded using the alternative
@@ -59,13 +108,37 @@ func NewWithNamespace(name string) string {
 // Panics if abc (after removing duplicates) has fewer than 2 characters.
 // The alphabet will be automatically sorted and deduplicated to ensure
 // consistency.
+//
+// Deprecated: Use NewV4WithAlphabet.
 func NewWithAlphabet(abc string) string {
-	enc := encoder{newAlphabet(abc)}
-	return enc.Encode(uuid.New())
+	return NewV4WithAlphabet(abc)
 }
 
-func hasPrefixCaseInsensitive(s, prefix string) bool {
+func hasPrefixFold(s, prefix string) bool {
 	return len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix)
+}
+
+func cutPrefixFold(s, prefix string) (string, bool) {
+	if hasPrefixFold(s, prefix) {
+		return s[len(prefix):], true
+	}
+	return s, false
+}
+
+func uuidV5FromName(name string) uuid.UUID {
+	if hasPrefixFold(name, "https://") || hasPrefixFold(name, "http://") {
+		return hashedUUID(uuid.NameSpaceURL, name)
+	}
+
+	if after, found := cutPrefixFold(name, "urn:oid:"); found {
+		return hashedUUID(uuid.NameSpaceOID, after)
+	}
+
+	if after, found := cutPrefixFold(name, "x500:"); found {
+		return hashedUUID(uuid.NameSpaceX500, after)
+	}
+
+	return hashedUUID(uuid.NameSpaceDNS, name)
 }
 
 func hashedUUID(space uuid.UUID, data string) (u uuid.UUID) {

--- a/shortuuid_example_test.go
+++ b/shortuuid_example_test.go
@@ -1,0 +1,36 @@
+package shortuuid
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NewV5FromName shows a simple case-sensitive variant of the deprecated
+// [NewWithNamespace] heuristic.
+func ExampleNewV5_fromName() {
+	NewV5FromName := func(name string) string {
+		if name == "" {
+			return NewV4()
+		}
+
+		if strings.HasPrefix(name, "https://") || strings.HasPrefix(name, "http://") {
+			return NewV5(NameSpaceURL, name)
+		}
+
+		if after, found := strings.CutPrefix(name, "urn:oid:"); found {
+			return NewV5(NameSpaceOID, after)
+		}
+
+		if after, found := strings.CutPrefix(name, "x500:"); found {
+			return NewV5(NameSpaceX500, after)
+		}
+
+		return NewV5(NameSpaceDNS, name)
+	}
+
+	fmt.Println(NewV5FromName("http://example.com"))
+	fmt.Println(NewV5FromName("urn:oid:1.2.840.113549"))
+	// Output:
+	// T35fvrnVz6SMSdh9y5hs8c
+	// HVizdopCKiLaGoTrVJrg9r
+}

--- a/shortuuid_test.go
+++ b/shortuuid_test.go
@@ -129,10 +129,36 @@ var testVector = []struct {
 	{"f9ee01c3-2015-4716-930e-4d5449810833", "nUfojcH2M5j9j3Tk5A8mf7"},
 }
 
+func TestNewV5(t *testing.T) {
+	tests := []struct {
+		namespace uuid.UUID
+		name      string
+		expected  string
+	}{
+		{NameSpaceDNS, "example.com/", "kueUMiGUbGccYhpZK8Czat"},
+		{NameSpaceURL, "http://www.example.com/", "nzUQAfy7CW4Dd4kzLguPSV"},
+		{NameSpaceOID, "1.2.840.113549", "HVizdopCKiLaGoTrVJrg9r"},
+		{NameSpaceX500, "CN=example,O=org", "KhUvFAV6shUNnwRqBDuz8i"},
+	}
+
+	for _, test := range tests {
+		if got := NewV5(test.namespace, test.name); got != test.expected {
+			t.Errorf("expected %q, got %q", test.expected, got)
+		}
+	}
+}
+
+func TestNewV5WithAlphabet(t *testing.T) {
+	abc := "23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxy="
+	if got := NewV5WithAlphabet(NameSpaceDNS, "example.com/", abc); got != "jtdTLhFTaFbbXgoYJ8ByZs" {
+		t.Errorf("expected %q, got %q", "jtdTLhFTaFbbXgoYJ8ByZs", got)
+	}
+}
+
 func TestNewWithNamespace(t *testing.T) {
 	tests := []struct {
-		name string
-		uuid string
+		name     string
+		expected string
 	}{
 		{"http://www.example.com/", "nzUQAfy7CW4Dd4kzLguPSV"},
 		{"HTTP://www.example.com/", "N9ZezvXJcoXvKzwiNmGYmH"},
@@ -140,12 +166,15 @@ func TestNewWithNamespace(t *testing.T) {
 		{"example.com/", "kueUMiGUbGccYhpZK8Czat"},
 		{"うえおなにぬねのウエオナニヌネノうえおなにぬねのウエオナニヌネノ", "Mp2Q7GQSRYnoDZyCtGttDg"},
 		{"う", "dTbaUbVKrhNkkZKEwZxLqa"},
+		{"urn:oid:1.2.840.113549", "HVizdopCKiLaGoTrVJrg9r"},
+		{"URN:OID:1.2.840.113549", "HVizdopCKiLaGoTrVJrg9r"},
+		{"x500:CN=example,O=org", "KhUvFAV6shUNnwRqBDuz8i"},
+		{"X500:CN=example,O=org", "KhUvFAV6shUNnwRqBDuz8i"},
 	}
-	for _, test := range tests {
-		u := NewWithNamespace(test.name)
 
-		if u != test.uuid {
-			t.Errorf("expected %q, got %q", test.uuid, u)
+	for _, test := range tests {
+		if got := NewWithNamespace(test.name); got != test.expected {
+			t.Errorf("expected %q, got %q", test.expected, got)
 		}
 	}
 
@@ -284,9 +313,9 @@ func TestAlphabet_MB(t *testing.T) {
 	}
 }
 
-func BenchmarkUUID(b *testing.B) {
+func BenchmarkNewV4(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		New()
+		NewV4()
 	}
 }
 
@@ -341,38 +370,38 @@ func BenchmarkDecodingB16_MB(b *testing.B) {
 	}
 }
 
-func BenchmarkNewWithAlphabet(b *testing.B) {
+func BenchmarkNewV4WithAlphabet(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = NewWithAlphabet("23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxy!")
+		_ = NewV4WithAlphabet("23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxy!")
 	}
 }
 
-func BenchmarkNewWithAlphabetB16(b *testing.B) {
+func BenchmarkNewV4WithAlphabetB16(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = NewWithAlphabet("0123456789abcdef")
+		_ = NewV4WithAlphabet("0123456789abcdef")
 	}
 }
 
-func BenchmarkNewWithAlphabetB16_MB(b *testing.B) {
+func BenchmarkNewV4WithAlphabetB16_MB(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = NewWithAlphabet("うえおなにぬねのウエオナニヌネノ")
+		_ = NewV4WithAlphabet("うえおなにぬねのウエオナニヌネノ")
 	}
 }
 
-func BenchmarkNewWithNamespace(b *testing.B) {
+func BenchmarkNewV5(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = NewWithNamespace("someaveragelengthurl")
+		_ = NewV5(NameSpaceDNS, "someaveragelengthurl")
 	}
 }
 
-func BenchmarkNewWithNamespaceHttp(b *testing.B) {
+func BenchmarkNewV5Http(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = NewWithNamespace("http://someaveragelengthurl.test")
+		_ = NewV5(NameSpaceURL, "http://someaveragelengthurl.test")
 	}
 }
 
-func BenchmarkNewWithNamespaceHttps(b *testing.B) {
+func BenchmarkNewV5Https(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = NewWithNamespace("https://someaveragelengthurl.test")
+		_ = NewV5(NameSpaceURL, "https://someaveragelengthurl.test")
 	}
 }


### PR DESCRIPTION
This also deprecates the old unversioned functions, but it will be kept indefinitely for backward compatibility.

The new api doesn't have anything like the old `NewWithNamespace` function, which had some heuristics to automatically pick a namespace for UUIDv5 and fell back to UUIDv4 when the name was empty. Instead, there are explicit `NewV4` and `NewV5` functions, and the user is expected to pick the right one. For v5, the namespace must be provided explicitly.